### PR TITLE
Fixed compilation error in tests.cpp when not building with TESTS=1

### DIFF
--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -2927,6 +2927,8 @@ void run_tests(bool dump_syntax_tree)
 
 #else
 
+using namespace std;
+
 void run_tests(bool)
 {
     cout << "Tests NOT compiled in. Build with TESTS=1" << endl;

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 
+#include "defs.h"
 #include <iostream>
 #include <iomanip>
 #include <cstdlib>
@@ -2926,8 +2927,6 @@ void run_tests(bool dump_syntax_tree)
 }
 
 #else
-
-using namespace std;
 
 void run_tests(bool)
 {


### PR DESCRIPTION
Compilation fails when building without `TESTS` enabled, because we are not using `std` namespace. (You can have a look at `#else` part of `src/tests.cpp`. This can be fixed by adding

```
using namespace std;
```
So `cout` and `endl` symbols are imported properly during compilation.

This patch fixes the above error.